### PR TITLE
Separate Diagnostics View

### DIFF
--- a/Sources/SymbolSource.Server.Basic.Host/Views/Home/Diagnostics.cshtml
+++ b/Sources/SymbolSource.Server.Basic.Host/Views/Home/Diagnostics.cshtml
@@ -1,0 +1,24 @@
+﻿@model SymbolSource.Server.Basic.DiagnosticsViewModel
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>SymbolSource Server Basic</title>
+    <link rel="shortcut icon" href="/favicon.png" />
+</head>
+<body>
+    <h1>SymbolSource Server Basic</h1>
+    
+    <h2>Self-diagnostics</h2>
+    <ul>
+        <li>SrcSrvPath Configuration Test - @Model.SrcSrvPathTest</li>
+        <li>NuGet Smoke Test -  <a href="@Model.NuGetSmokeTest.Key">@Model.NuGetSmokeTest.Value</a></li>
+        <li>NuGet Push Test - <a href="@Model.NuGetPushTest.Key">@Model.NuGetPushTest.Value</a></li>
+        <li>NuGet Feed Test - <a href="@Model.NuGetFeedTest.Key">@Model.NuGetFeedTest.Value</a></li>
+        <li>OpenWrap Smoke Test - <a href="@Model.OpenWrapSmokeTest.Key">@Model.OpenWrapSmokeTest.Value</a></li>
+        <li>OpenWrap Push Test - <a href="@Model.OpenWrapPushTest.Key">@Model.OpenWrapPushTest.Value</a></li>
+        <li>OpenWrap Feed Test - <a href="@Model.OpenWrapFeedTest.Key">@Model.OpenWrapFeedTest.Value</a></li>
+    </ul>
+</body>
+</html>

--- a/Sources/SymbolSource.Server.Basic.Host/Views/Home/Index.cshtml
+++ b/Sources/SymbolSource.Server.Basic.Host/Views/Home/Index.cshtml
@@ -27,15 +27,5 @@
     <p>
         <strong><code>@Model.OpenWrapUrl</code></strong>
     </p>
-    <h2>Self-diagnostics</h2>
-    <ul>
-        <li>SrcSrvPath Configuration Test - @Model.SrcSrvPathTest</li>
-        <li>NuGet Smoke Test -  <a href="@Model.NuGetSmokeTest.Key">@Model.NuGetSmokeTest.Value</a></li>
-        <li>NuGet Push Test - <a href="@Model.NuGetPushTest.Key">@Model.NuGetPushTest.Value</a></li>
-        <li>NuGet Feed Test - <a href="@Model.NuGetFeedTest.Key">@Model.NuGetFeedTest.Value</a></li>
-        <li>OpenWrap Smoke Test - <a href="@Model.OpenWrapSmokeTest.Key">@Model.OpenWrapSmokeTest.Value</a></li>
-        <li>OpenWrap Push Test - <a href="@Model.OpenWrapPushTest.Key">@Model.OpenWrapPushTest.Value</a></li>
-        <li>OpenWrap Feed Test - <a href="@Model.OpenWrapFeedTest.Key">@Model.OpenWrapFeedTest.Value</a></li>
-    </ul>
 </body>
 </html>

--- a/Sources/SymbolSource.Server.Basic/HomeController.cs
+++ b/Sources/SymbolSource.Server.Basic/HomeController.cs
@@ -16,6 +16,10 @@ namespace SymbolSource.Server.Basic
         public string NuGetPushUrl;
         public string NuGetFeedUrl;
         public string OpenWrapUrl;
+    }
+
+    public class DiagnosticsViewModel
+    {
         public string SrcSrvPathTest;
         public KeyValuePair<string, string> NuGetSmokeTest;
         public KeyValuePair<string, string> OpenWrapSmokeTest;
@@ -59,15 +63,22 @@ namespace SymbolSource.Server.Basic
                     VisualStudioUrl = GetVisualStudioUrl(),
                     NuGetPushUrl = GetNuGetPushUrl(),
                     NuGetFeedUrl = GetNuGetFeedUrl(),
-                    OpenWrapUrl = GetOpenWrapUrl(),
-                    SrcSrvPathTest = Directory.Exists(ConfigurationManager.AppSettings["SrcSrvPath"]) ? "OK" : "Directory not found",
-                    NuGetSmokeTest = InlineTest(Url.Action("SmokeTest", new { url = Url.Content("~/NuGet/FeedService.mvc") })),
-                    OpenWrapSmokeTest = InlineTest(Url.Action("SmokeTest", new { url = Url.Content("~/OpenWrap/index.wraplist") })),
-                    NuGetPushTest = InlineTest(Url.Action("NuGetPushTest")),
-                    NuGetFeedTest = InlineTest(Url.Action("NuGetFeedTest")),
-                    OpenWrapPushTest = InlineTest(Url.Action("OpenWrapPushTest")),
-                    OpenWrapFeedTest = InlineTest(Url.Action("OpenWrapFeedTest")),
+                    OpenWrapUrl = GetOpenWrapUrl()
                 });
+        }
+
+        public ActionResult Diagnostics()
+        {
+            return View(new DiagnosticsViewModel
+            {
+                SrcSrvPathTest = Directory.Exists(ConfigurationManager.AppSettings["SrcSrvPath"]) ? "OK" : "Directory not found",
+                NuGetSmokeTest = InlineTest(Url.Action("SmokeTest", new { url = Url.Content("~/NuGet/FeedService.mvc") })),
+                OpenWrapSmokeTest = InlineTest(Url.Action("SmokeTest", new { url = Url.Content("~/OpenWrap/index.wraplist") })),
+                NuGetPushTest = InlineTest(Url.Action("NuGetPushTest")),
+                NuGetFeedTest = InlineTest(Url.Action("NuGetFeedTest")),
+                OpenWrapPushTest = InlineTest(Url.Action("OpenWrapPushTest")),
+                OpenWrapFeedTest = InlineTest(Url.Action("OpenWrapFeedTest"))
+            });
         }
 
         private KeyValuePair<string, string> InlineTest(string url)


### PR DESCRIPTION
This commit should separate the Diagnostics View from the default Index.
It is not very practical to run the diagnostics every single time a developer browses the index page of the symbolserver application.
